### PR TITLE
v0.0.35

### DIFF
--- a/src/ragtime/expe.py
+++ b/src/ragtime/expe.py
@@ -222,6 +222,14 @@ class Expe(RagtimeList[QA]):
             for json_qa in qa_list:
                 qa:QA = QA(**json_qa)
                 self.append(qa)
+
+    def filter_answer(self, llm_facts_name: str):
+        """
+        Filters the current Expe object to include only the QA pairs with answers from the specified LLM.
+        """
+        for qa in self:
+            filtered_answers = [a for a in qa.answers if a.llm_answer and a.llm_answer.name == llm_facts_name]
+            qa.answers = Answers(items=filtered_answers)
     
     # TODO: Cannot implement this function due to circular imports issue (need objects from generators.py objects and generators.py needs
     # expe.py objects too) - if someone finds a way, that would be nice since it would allow to easily chain Answer, Facts and Eval generation

--- a/src/ragtime/generators.py
+++ b/src/ragtime/generators.py
@@ -622,7 +622,7 @@ class FactGenerator(TextGenerator):
     async def gen_for_qa(self, qa:QA, start_from:StartFrom=StartFrom.beginning, b_missing_only:bool=False, only_llms:list[str] = None):
         """Create Facts based on the first Answer in the QA having human Eval equals 1 """
        
-        ans:Answer = next((a for a in qa.answers if a.eval and a.eval.human == 1.0))
+        ans:Answer = next((a for a in qa.answers if a.eval and a.eval.human == 1.0), None)
         if ans:
             logger.prefix += f'[FactGen][{self.llm.name}]'
             model_str:str = f" associated with answer from model {ans.llm_answer.full_name}" if ans.llm_answer else ""


### PR DESCRIPTION
### Pull Request Description

#### Changes Made in `expe.py`:
Added a new function `filter_answer` to the `Expe` class, enabling the extraction of answers associated with a specific LLM. This function iterates through the QA pairs in the `Expe` object and filters the answers to include only those provided by the specified LLM.

```python
def filter_answer(self, llm_facts_name: str):
    """
    Filters the current Expe object to include only the QA pairs with answers from the specified LLM.
    """
    for qa in self:
        filtered_answers = [a for a in qa.answers if a.llm_answer and a.llm_answer.name == llm_facts_name]
        qa.answers = Answers(items=filtered_answers)
```

#### Changes Made in `generators.py`:
Modified line 625 by changing:
```python
ans:Answer = next((a for a in qa.answers if a.eval and a.eval.human == 1.0))
```
to:
```python
ans:Answer = next((a for a in qa.answers if a.eval and a.eval.human == 1.0), None)
```
The change adds a default value of `None` to the `next` function call. This adjustment prevents the function from raising a `StopIteration` exception when there are no matching answers with a human evaluation score of `1.0`. Instead, it returns `None`
